### PR TITLE
Allow FSM states to return output from next!()

### DIFF
--- a/src/fsm_check.rs
+++ b/src/fsm_check.rs
@@ -1,15 +1,15 @@
-use fsm::{Fsm, FsmHandler};
+use fsm::{Fsm, StateFn, FsmTypes};
 use constraints::Constraints;
 
-pub struct Checker<T: FsmHandler> {
+pub struct Checker<T: FsmTypes> {
     fsm: Fsm<T>,
     constraints: Constraints<T::Context>
 }
 
-impl<T: FsmHandler> Checker<T> {
-    pub fn new(ctx: T::Context, constraints: Constraints<T::Context>) -> Checker<T> {
+impl<T: FsmTypes> Checker<T> {
+    pub fn new(ctx: T::Context, state: StateFn<T>, constraints: Constraints<T::Context>) -> Checker<T> {
         Checker {
-            fsm: Fsm::<T>::new(ctx),
+            fsm: Fsm::<T>::new(ctx, state),
             constraints: constraints
         }
     }
@@ -19,7 +19,7 @@ impl<T: FsmHandler> Checker<T> {
         for msg in msgs {
             let (from, ctx) = self.fsm.get_state();
             try!(self.constraints.check_preconditions(from, &ctx));
-            self.fsm.send_msg(msg);
+            self.fsm.send(msg);
             let (to, ctx) = self.fsm.get_state();
             try!(self.constraints.check_postconditions(from, &ctx));
             try!(self.constraints.check_invariants(&ctx));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,5 @@ pub mod fsm_check;
 pub use fsm::{
     Fsm,
     StateFn,
-    FsmHandler,
+    FsmTypes
 };


### PR DESCRIPTION
Previously, FSMs communicated with the each other and the outside world via channels passed
in as part of the context. Now when an FSM state function calls `next!` it can
optionally return output. This output can be messages meant to be routed to
other FSMs or sent on the wire.

The FsmHandler trait was renamed to FsmTypes and now only contains the
types used to parameterize the FSM module. There is no longer an
`initial_state()` function because of this, so the initial state is now
passed into the FSM constructor. Due to the change in the `next!` macro
so that it returns the next state and output, the initial state is
constructed using the new `state_fn` macro.
